### PR TITLE
feat: Transfer or copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Transfer issues from one repo to another, even across orgs.
 
+## Features
+
+[Transferring an issue to another repository](https://docs.github.com/en/issues/tracking-your-work-with-issues/transferring-an-issue-to-another-repository) describes GitHub’s built-in issue transfer functionality. The table below contrasts built-in transfers with this action’s transfers:
+
+| Transfers                            | Built-in                     | This Action                    |
+| :----------------------------------- | :--------------------------- | :----------------------------- |
+| Between repos in the same org        | 🟡 Supported, without labels | 🟢 Supported                   |
+| Between repos in different orgs      | 🔴 Not Supported             | 🟡 Supported, without comments |
+| Between public repos                 | 🟡 Supported, without labels | 🟢 Supported                   |
+| Between private repos                | 🟡 Supported, without labels | 🟢 Supported                   |
+| From a public repo to a private repo | 🟡 Supported, without labels | 🟢 Supported                   |
+| From a private repo to a public repo | 🔴 Not Supported             | 🟡 Supported, without comments |
+
 ## Usage
 
 ### Inputs

--- a/src/lib/repository.ts
+++ b/src/lib/repository.ts
@@ -258,7 +258,7 @@ export class Repository {
         owner: this.owner,
         repo: this.repo,
         issue_number: transferredIssue.number,
-        labels
+        labels: labels.map(({ name }) => name)
       }))?.data
       return transferredIssue
     } else {

--- a/src/lib/repository.ts
+++ b/src/lib/repository.ts
@@ -8,6 +8,31 @@ type Unwrapped<T> = T extends Promise<infer U>
 type Issue = Unwrapped<ReturnType<Client["rest"]["issues"]["get"]>>["data"];
 type Label = Exclude<Unwrapped<Issue["labels"]>, string>;
 
+/** https://docs.github.com/en/graphql/reference/mutations#transferissue */
+type TransferIssueReturnFields = {
+  clientMutationId: string,
+  issue: Pick<Issue, "id" | "number" | "url" | "state" | "title" | "labels" | "locked">
+}
+
+interface StrictLabel extends Label {
+  name: string
+}
+/**
+ * Type guard for named object labels. `issues.get`, `issues.create`,
+ * and `issues.addLabels` have divering label types; this guard normalizes the type.
+ * @param label Any valid label type (e.g. named object, unnamed object, string).
+ * @returns Label is a named object.
+ */
+function isStrictLabel(label: string | Label): label is StrictLabel {
+  return label !== null && typeof label === "object" && label.hasOwnProperty("name") && typeof label.name === "string" && label.name.length > 0;
+}
+
+/** Repository visibility. */
+enum Visibility {
+  Public,
+  Private
+}
+
 /** Number of issues to retrieve per page. Increasing this from 30 (the default)
  * to 100 (the max) in order to decrease the number of requests.
  * Docs: https://docs.github.com/en/rest/reference/issues#list-repository-issues--parameters
@@ -20,6 +45,7 @@ export class Repository {
   #issueCache: Issue[] = [];
   owner: string;
   repo: string;
+  visibility: Visibility | undefined;
 
   constructor(
     client: Client,
@@ -79,6 +105,20 @@ export class Repository {
   };
 
   /**
+   * Populate the repository’s visibility. If visibility cannot be determined,
+   * assume the repo is private. Private repos have stricter pre-transfer checks,
+   * i.e. the copy operation is more likely to be used, and since the copy
+   * operation has fewer failure modes, it’s safer to assume repos are private.
+   */
+  #populateVisibility = async () => {
+    const data = (await this.#client.rest.repos.get({
+      owner: this.owner,
+      repo: this.repo
+    }))?.data
+    this.visibility = data.private === false ? Visibility.Public : Visibility.Private
+  }
+
+  /**
    * Create a label, if the label doesn’t already exist. This method is private
    * because it’s not core functionality (this action’s focus is issue transfers)
    * however, label creation is a necessary pre-requisite for issue transfers.
@@ -127,49 +167,105 @@ export class Repository {
 
   /**
    * Create a new issue with the same attributes as the provided issue.
-   * This method is used to copy an issue to the destination repository.
+   * This method is used to transfer or copy an issue to the destination repository.
    */
-  transferIssue = async (issue: Issue): Promise<Issue | undefined> => {
-    const { source } = issue.repository_url.match(
-      /^(?<_>.+)\/(?<source>.+\/.+)$/
-    )!.groups as { source: string };
+  transferIssue = async (issue: Issue): Promise<Issue | TransferIssueReturnFields["issue"] | undefined> => {
+    const {sourceOwner, sourceRepo} = issue.repository_url.match(
+      /^(?<_>.+)\/(?<sourceOwner>.+)\/(?<sourceRepo>.+)$/
+    )!.groups as { sourceOwner: string, sourceRepo: string };
+    const source = new Repository(this.#client, { owner: sourceOwner, repo: sourceRepo })
 
     // Return early if the issue has already been transferred.
     if (this.#issueCache.length === 0) {
-      await this.#populateIssueCache(source);
+      await this.#populateIssueCache(`${source.owner}/${source.repo}`);
     }
     const duplicateIssue = this.#issueCache.find(
       ({ title }) => title === issue.title
     );
     if (duplicateIssue) {
       console.log(
-        `Skipping issue transfer. Issue source (${source}#${issue.number}) already exists at destination (${this.owner}/${this.repo}#${duplicateIssue.number}).`
+        `Skipping issue transfer. Issue source (${source.owner}/${source.repo}#${issue.number}) already exists at destination (${this.owner}/${this.repo}#${duplicateIssue.number}).`
       );
       return;
     }
 
     // Only labels which exist can be added to issues, so create missing labels in the destination repo.
-    for (const _label of issue.labels) {
-      let label = _label;
-      if (typeof _label === "string") {
-        label = {
-          name: _label,
-        };
+    const transferredFromLabel: StrictLabel = {
+      name: `transferred-from: ${source.owner}/${source.repo}`.substring(0, 50)
+    };
+    const labels = issue.labels.reduce<StrictLabel[]>((labels, label) => {
+      if (isStrictLabel(label)) {
+        labels.push(label)
+      } else if (typeof label === "string") {
+        labels.push({ name: label })
       }
+      return labels
+    }, [transferredFromLabel])
+    for (const label of labels) {
       await this.#createLabel(label as Label);
     }
-    const transferredFromLabel: Label = {
-      name: `transferred-from: ${source}`.substring(0, 50),
-    };
-    await this.#createLabel(transferredFromLabel);
 
-    return (
-      await this.#client.rest.issues.create({
+    /** Whether this is an intra-org operation. */
+    const canTransferBetweenOrgs = source.owner.toLowerCase() === this.owner.toLowerCase();
+
+    // Set the source repository’s `visibility` attribute.
+    await source.#populateVisibility();
+    /** Whether this is a public-to-public, public-to-private, or private-to-private operation. */
+    const canTransferBetweenVisibilities = source.visibility === Visibility.Public || (source.visibility === Visibility.Private && this.visibility === Visibility.Private);
+
+    if (canTransferBetweenOrgs && canTransferBetweenVisibilities) {
+      // Transfer operation is allowed.
+      const sourceIssueId = (await this.#client.graphql<{ id: string }>(`query {
+        repository(owner: ${source.owner}, name: ${source.repo}) {
+          issue(number: ${issue.number}) {
+            id
+          }
+        }
+      }`))?.id
+      const destinationRepoId = (await this.#client.graphql<{ id: string }>(`query {
+        repository(owner: ${this.owner}, name: ${this.repo}) {
+          id
+        }
+      }`))?.id
+      const transferredIssue = (await this.#client.graphql<TransferIssueReturnFields>(`mutation {
+        transferIssue(
+          input: {
+            issueId: ${sourceIssueId}
+            repositoryId: ${destinationRepoId}
+          }
+        ) {
+          issue {
+            id
+            number
+            url
+            state
+            title
+            labels(first: 100) {
+              nodes {
+                name
+              }
+            }
+            locked
+          }
+        }
+      }`))?.issue
+      // https://docs.github.com/en/issues/tracking-your-work-with-issues/transferring-an-issue-to-another-repository notes that:
+      // “The issue's labels…are not retained.” As a workaround, re-add them.
+      transferredIssue.labels = (await this.#client.rest.issues.addLabels({
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: transferredIssue.number,
+        labels
+      }))?.data
+      return transferredIssue
+    } else {
+      // Transfer operation is disallowed. Falling back to copy operation.
+      return (await this.#client.rest.issues.create({
         owner: this.owner,
         repo: this.repo,
         title: issue.title,
         body: issue.body || "",
-        labels: [...issue.labels, transferredFromLabel],
+        labels,
         assignee: !issue.assignees ? issue.assignee?.login : undefined,
         assignees: issue.assignees?.reduce(
           (assignees: string[] | undefined, assignee) => {
@@ -181,7 +277,7 @@ export class Repository {
           },
           undefined
         ),
-      })
-    )?.data;
+      }))?.data
+    }
   };
 }

--- a/src/lib/repository.ts
+++ b/src/lib/repository.ts
@@ -210,6 +210,9 @@ export class Repository {
 
     // Set the source repository’s `visibility` attribute.
     await source.#populateVisibility();
+    if (typeof this.visibility === "undefined") {
+      await this.#populateVisibility();
+    }
     /** Whether this is a public-to-public, public-to-private, or private-to-private operation. */
     const canTransferBetweenVisibilities = source.visibility === Visibility.Public || (source.visibility === Visibility.Private && this.visibility === Visibility.Private);
 

--- a/src/lib/transfer-issues.ts
+++ b/src/lib/transfer-issues.ts
@@ -55,7 +55,7 @@ export async function transferIssues({
     if (!sourceIssue) {
       throw new Error(`Failed to retrieve issue: ${source}#${issueNumber}.`);
     }
-    // Copy issue to destination repo.
+    // Transfer or copy issue to destination repo.
     const destinationIssue = await destinationRepo.transferIssue(sourceIssue);
     if (destinationIssue?.number !== undefined) {
       console.log(


### PR DESCRIPTION
Extends [smockle/action-transfer-issues](https://github.com/smockle/action-transfer-issues) to use [octokit/graphql.js](https://github.com/octokit/graphql.js/#send-a-simple-query) to perform enhanced[^1] [`transferIssue`](https://docs.github.com/en/graphql/reference/mutations#transferissue) mutations where possible[^2].

[^1]: “Enhanced” because—unlike the [built-in feature](https://docs.github.com/en/issues/tracking-your-work-with-issues/transferring-an-issue-to-another-repository)—`smockle/action-transfer-issues` preserves labels.
[^2]: The [“transfer” strategy](https://github.com/smockle/action-transfer-issues/blob/a988acd5371fe690e251148e16f07efd5ab43583/src/lib/repository.ts#L217-L260) is used for transfers that are both:
    - between repos in the same org (i.e. “intra-org”), and
    - either between public repos—or, from a public repo to a private repo
    
    In other cases, the [“copy” strategy](https://github.com/smockle/action-transfer-issues/blob/a988acd5371fe690e251148e16f07efd5ab43583/src/lib/repository.ts#L262-L280) is used. The “copy” strategy does’t (yet) preserve comments, so (for now) the “transfer” strategy is preferred.